### PR TITLE
Fixed case of single ligand when docking with gnina (.sdf vs. .pdbqt)

### DIFF
--- a/docking_parallel.py
+++ b/docking_parallel.py
@@ -213,10 +213,10 @@ if __name__ == '__main__' or jug.is_jug_running():
     args = parser.parse_args()
     if len(args.ligand_list) == 1:
         ligand_list_path = Path(args.ligand_list[0])
-        if ligand_list_path.suffix != '.pdbqt':
-            ligand_paths = ligand_list_path.read_text().split()
-        else:
+        if ligand_list_path.suffix == '.pdbqt' or ligand_list_path.suffix == '.sdf' :
             ligand_paths = args.ligand_list
+        else:
+            ligand_paths = ligand_list_path.read_text().split()
     else:
         ligand_paths = args.ligand_list
     path_receptor = Path(args.receptor_dir)


### PR DESCRIPTION
Previously, if you submitted a single term to ligand list i.e. docking a single ligand or submitting a txt file with a list of ligands, it would have an exception for a pdbqt. I added functionality to include .sdf so gnina docking can occur.